### PR TITLE
Bugfix - Trip Date

### DIFF
--- a/src/destinations.js
+++ b/src/destinations.js
@@ -10,13 +10,13 @@ function findDestination(locationID, destinationsArray) {
   }
 }
 
-function getDestDisplayInfo(destination, tripsArray) {
-  const dateArray = tripsArray.find(trip => trip.destinationID === destination.id).date.split('/');
+function getDestDisplayInfo(tripObj) {
+  const dateArray = tripObj.date.split('/');
   const date = `${dateArray[1]}/${dateArray[2]}/${dateArray[0]}`;
   const displayInfo = {
-    name: destination.destination,
-    image: destination.image,
-    alt: destination.alt,
+    name: tripObj.destination.destination,
+    image: tripObj.destination.image,
+    alt: tripObj.destination.alt,
     date,
   };
   return displayInfo;

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -123,8 +123,8 @@ function setData(userID) {
 function renderDom(userID) {
   currentTraveler = setTraveler(userID, travelersData);
   let trips = filterTrips(currentTraveler, tripsData);
-  let organizedTrips = organizeTrips(trips);
-  let tripDisplayDetails = getTripDisplayInfo(organizedTrips, destinationsData);
+  let organizedTrips = organizeTrips(trips, destinationsData);
+  let tripDisplayDetails = getTripDisplayInfo(organizedTrips);
   let currentYear = findCurrentYear(organizedTrips);
   let stats = calculateStats(
     organizedTrips,

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -199,7 +199,8 @@ function handleSearch(e) {
 }
 
 function checkTripDate() {
-  const tripDates = tripsData.map((trip) => trip.date);
+  const userTrips = filterTrips(currentTraveler, tripsData);
+  const tripDates = userTrips.map((trip) => trip.date);
   const inputDate = dateInput.value.split("-").join("/");
   if (tripDates.includes(inputDate)) {
     return false;

--- a/src/trips.js
+++ b/src/trips.js
@@ -9,7 +9,6 @@ function organizeTrips(userTrips, destinationsArray) {
   userTrips.forEach(trip => {
     trip.destination = findDestination(trip.destinationID, destinationsArray)
   })
-  console.log('User Trips', userTrips)
   const tripsObject = userTrips.reduce(
     (obj, trip) => {
       if (trip.status === "approved") {
@@ -24,7 +23,6 @@ function organizeTrips(userTrips, destinationsArray) {
       pending: [],
     }
   );
-  console.log('Trips Object', tripsObject)
   return tripsObject;
 }
 
@@ -106,7 +104,6 @@ function getTripDisplayInfo({ approved, pending }) {
       ? pending.map((trip) => getDestDisplayInfo(trip))
       : "No Pending Trips 🌍",
   };
-  console.log('allDisplayInfo', allDisplayInfo)
   return allDisplayInfo;
 }
 

--- a/src/trips.js
+++ b/src/trips.js
@@ -5,7 +5,11 @@ function filterTrips({ id }, tripsArray) {
   return trips;
 }
 
-function organizeTrips(userTrips) {
+function organizeTrips(userTrips, destinationsArray) {
+  userTrips.forEach(trip => {
+    trip.destination = findDestination(trip.destinationID, destinationsArray)
+  })
+  console.log('User Trips', userTrips)
   const tripsObject = userTrips.reduce(
     (obj, trip) => {
       if (trip.status === "approved") {
@@ -20,6 +24,7 @@ function organizeTrips(userTrips) {
       pending: [],
     }
   );
+  console.log('Trips Object', tripsObject)
   return tripsObject;
 }
 
@@ -92,21 +97,16 @@ function calculateStats({ approved }, tripsArray, destinationsArray, year) {
   return travStats;
 }
 
-function getTripDisplayInfo({ approved, pending }, destinationsArray) {
-  const pastDestinations = approved.map((trip) =>
-    findDestination(trip.destinationID, destinationsArray)
-  );
-  const pendingDestinations = pending.map((trip) =>
-    findDestination(trip.destinationID, destinationsArray)
-  );
+function getTripDisplayInfo({ approved, pending }) {
   const allDisplayInfo = {
-    past: pastDestinations.length
-      ? pastDestinations.map((dest) => getDestDisplayInfo(dest, approved))
+    past: approved.length
+      ? approved.map((trip) => getDestDisplayInfo(trip))
       : "No Trips 🌍",
-    pending: pendingDestinations.length
-      ? pendingDestinations.map((dest) => getDestDisplayInfo(dest, pending))
+    pending: pending.length
+      ? pending.map((trip) => getDestDisplayInfo(trip))
       : "No Pending Trips 🌍",
   };
+  console.log('allDisplayInfo', allDisplayInfo)
   return allDisplayInfo;
 }
 

--- a/test/destinations-test.js
+++ b/test/destinations-test.js
@@ -23,7 +23,7 @@ describe("Destinations", function () {
     trips1 = filterTrips(traveler1, testTrips);
     trips2 = filterTrips(traveler2, testTrips);
     trips3 = filterTrips(traveler3, testTrips);
-    traveler1Trips = organizeTrips(trips1);
+    traveler1Trips = organizeTrips(trips1, testDestinations);
     dest1 = findDestination(1, testDestinations);
   });
 
@@ -48,7 +48,7 @@ describe("Destinations", function () {
 
   describe("Get Destination Display Info", function () {
     it("should return an object with one destination's details to display", function () {
-      const destInfo = getDestDisplayInfo(dest1, traveler1Trips.approved);
+      const destInfo = getDestDisplayInfo(traveler1Trips.approved[0]);
 
       expect(destInfo).to.be.an("object");
       expect(destInfo.name).to.equal("Lima, Peru");

--- a/test/trips-test.js
+++ b/test/trips-test.js
@@ -38,8 +38,8 @@ describe("Trips", function () {
     trips2 = filterTrips(traveler2, testTrips);
     trips3 = filterTrips(traveler3, testTrips);
     trips4 = filterTrips(traveler4, testTrips);
-    traveler1Trips = organizeTrips(trips1);
-    traveler4Trips = organizeTrips(trips4);
+    traveler1Trips = organizeTrips(trips1, testDestinations);
+    traveler4Trips = organizeTrips(trips4, testDestinations);
     trav1DisplayInfo = getTripDisplayInfo(traveler1Trips, testDestinations);
     currentTraveler = traveler1;
     dest = testDestinations[0];
@@ -52,6 +52,15 @@ describe("Trips", function () {
       expect(trips1[0]).to.deep.equal({
         date: "2023/02/14",
         destinationID: 1,
+        destination: {
+          id: 1,
+          destination: "Lima, Peru",
+          estimatedLodgingCostPerDay: 70,
+          estimatedFlightCostPerPerson: 400,
+          image:
+            "https://images.unsplash.com/photo-1489171084589-9bf89e1baa8b?ixid=MnwyMzU4MzB8MHwxfGFsbHwxfHx8fHx8fHx8fDE2Mzg1ODU0NzE&ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80",
+          alt: "city with buildings during the day",
+        },
         duration: 6,
         id: 1,
         status: "approved",
@@ -83,6 +92,15 @@ describe("Trips", function () {
           {
             date: "2023/02/14",
             destinationID: 1,
+            destination: {
+              id: 1,
+              destination: "Lima, Peru",
+              estimatedLodgingCostPerDay: 70,
+              estimatedFlightCostPerPerson: 400,
+              image:
+                "https://images.unsplash.com/photo-1489171084589-9bf89e1baa8b?ixid=MnwyMzU4MzB8MHwxfGFsbHwxfHx8fHx8fHx8fDE2Mzg1ODU0NzE&ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80",
+              alt: "city with buildings during the day",
+            },
             duration: 6,
             id: 1,
             status: "approved",
@@ -93,6 +111,15 @@ describe("Trips", function () {
           {
             date: "2026/04/10",
             destinationID: 7,
+            destination: {
+              id: 7,
+              destination: "Dubai, UAE",
+              estimatedLodgingCostPerDay: 200,
+              estimatedFlightCostPerPerson: 900,
+              image:
+                "https://images.unsplash.com/photo-1503443207922-dff7d543fd0e?ixid=MnwyMzU4MzB8MHwxfGFsbHwxfHx8fHx8fHx8fDE2Mzg1ODU0NzE&ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80",
+              alt: "city with tall buildings and a fountain in the foreground",
+            },
             duration: 4,
             id: 7,
             status: "approved",
@@ -105,6 +132,15 @@ describe("Trips", function () {
           {
             date: "2025/01/10",
             destinationID: 4,
+            destination: {
+              id: 4,
+              destination: "Paris, France",
+              estimatedLodgingCostPerDay: 103,
+              estimatedFlightCostPerPerson: 395,
+              image:
+                "https://images.unsplash.com/photo-1508818619205-0a3a90aadc5d?ixid=MnwyMzU4MzB8MHwxfGFsbHwxfHx8fHx8fHx8fDE2Mzg1ODU0NzE&ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80",
+              alt: "city during the day with eiffel tower",
+            },
             duration: 4,
             id: 4,
             status: "pending",
@@ -116,7 +152,7 @@ describe("Trips", function () {
       });
     });
     it("should present an empty array if no trips match the respective status", function () {
-      const traveler3Trips = organizeTrips(trips3);
+      const traveler3Trips = organizeTrips(trips3, testDestinations);
 
       expect(traveler3Trips.pending).to.deep.equal([]);
     });
@@ -124,7 +160,7 @@ describe("Trips", function () {
 
   describe("Find Current Year", function () {
     it("should return the year of a traveler's most recent past trip", function () {
-      const traveler3Trips = organizeTrips(trips3);
+      const traveler3Trips = organizeTrips(trips3, testDestinations);
       const currentYear = findCurrentYear(traveler3Trips);
 
       expect(currentYear).to.equal("2026");


### PR DESCRIPTION
# Summary <!-- what does this PR accomplish? -->
- The trip object contained the correct date, but if more than one trip was scheduled for the same destination, the date of the first instance would display for all trip cards. This was solved by accessing all displayed trip information (including destination details) from the same object.
- A bug was discovered that wouldn't allow different users to schedule trips on the same date. This was solved by validating the newly planned trip date based on the trips of the individual traveler, and not the entire trips dataset.
